### PR TITLE
fix: close out no-input GitHub issues — perf, a11y, features

### DIFF
--- a/docs/KEY_ROTATION.md
+++ b/docs/KEY_ROTATION.md
@@ -1,0 +1,58 @@
+# Secret & API Key Rotation Runbook
+
+Issue **#292**. Production-grade procedure for rotating ConfScout secrets
+without downtime.
+
+## Secrets inventory
+
+| Secret | Where used | Rotate when |
+|--------|------------|-------------|
+| `DATABASE_URL` | Prisma, Postgres pool | Credential leak, staff change |
+| `NEXTAUTH_SECRET` | Session JWT signing | Leak, quarterly hygiene |
+| `ZOHO_PASSWORD` / SMTP | Digest email | Leak, password policy |
+| `UPSTASH_REDIS_REST_TOKEN` | Cache + rate limit | Leak, quarterly |
+| `GROQ_API_KEY` | Recommendations / digest AI | Leak, provider rotation |
+| `CACHE_INVALIDATION_SECRET` | Ingest → `/api/cache/invalidate` | Leak, after CI secret compromise |
+| `PAT_TOKEN` (GitHub) | Ingest workflow push | Leak, staff change |
+| Sentry DSN / auth token | Error monitoring | Leak |
+
+Never commit values. Store only in Vercel Project Env + GitHub Actions secrets.
+
+## Standard rotation steps
+
+1. **Generate** the new secret (use a CSPRNG; min 32 bytes for HMAC secrets).
+2. **Add** the new value alongside the old one if dual-read is supported
+   (NextAuth does not dual-read — plan a short deploy window).
+3. **Deploy** application with the new env var (Vercel → Redeploy).
+4. **Verify** health (`GET /api/health`), sign-in, digest dry-run, cache
+   invalidate from Actions.
+5. **Revoke** the old secret at the provider (Upstash, Groq, Zoho, GitHub).
+6. **Record** rotation date in the team password manager / ops log.
+
+## NextAuth secret specifically
+
+Changing `NEXTAUTH_SECRET` invalidates all existing sessions. Prefer rotating
+during low traffic and announce a forced re-login.
+
+## CACHE_INVALIDATION_SECRET
+
+1. Generate: `openssl rand -hex 32`
+2. Update Vercel env + GitHub Actions secret `CACHE_INVALIDATION_SECRET`
+3. Redeploy app, then re-run ingest workflow to confirm `Bearer` auth works
+
+## Quarterly checklist
+
+- [ ] Rotate `NEXTAUTH_SECRET` (or confirm still private)
+- [ ] Rotate Upstash token
+- [ ] Rotate Groq key
+- [ ] Review GitHub PATs and remove unused
+- [ ] Confirm no secrets in git history (`git log -p | rg -i 'password|secret|api_key'`)
+
+## Incident response
+
+If a secret is exposed in a PR, log, or chat:
+
+1. Rotate immediately (do not wait for the quarterly window).
+2. Revoke the old credential first when the provider allows dual-active keys;
+   otherwise rotate then deploy within minutes.
+3. Open a private security note and audit access logs for the secret’s surface.

--- a/docs/KEY_ROTATION.md
+++ b/docs/KEY_ROTATION.md
@@ -1,7 +1,9 @@
 # Secret & API Key Rotation Runbook
 
 Issue **#292**. Production-grade procedure for rotating ConfScout secrets
-without downtime.
+while keeping the site available. **Service uptime is not the same as
+session continuity** — some rotations (especially `NEXTAUTH_SECRET`) force
+users to sign in again even when the app never goes offline.
 
 ## Secrets inventory
 
@@ -18,31 +20,85 @@ without downtime.
 
 Never commit values. Store only in Vercel Project Env + GitHub Actions secrets.
 
-## Standard rotation steps
+## Standard rotation steps (non-database secrets)
 
-1. **Generate** the new secret (use a CSPRNG; min 32 bytes for HMAC secrets).
+Use this sequence for Upstash, Groq, Zoho, GitHub PAT, Sentry, and
+`CACHE_INVALIDATION_SECRET`. **Do not use this sequence for `DATABASE_URL`**
+— see [Postgres / DATABASE_URL](#postgres--database_url) below.
+
+1. **Generate** the new secret (CSPRNG; min 32 bytes for HMAC secrets).
 2. **Add** the new value alongside the old one if dual-read is supported
-   (NextAuth does not dual-read — plan a short deploy window).
-3. **Deploy** application with the new env var (Vercel → Redeploy).
-4. **Verify** health (`GET /api/health`), sign-in, digest dry-run, cache
-   invalidate from Actions.
-5. **Revoke** the old secret at the provider (Upstash, Groq, Zoho, GitHub).
+   (NextAuth does **not** dual-read — plan a short auth disruption window).
+3. **Deploy** the application with the new env var (Vercel → Redeploy).
+4. **Verify** (must fail the check on non-2xx — do not swallow errors):
+   - Health: `curl --fail --silent --show-error "$APP_URL/api/health"`
+   - Sign-in still works (see NextAuth section)
+   - Cache invalidate (see CACHE_INVALIDATION_SECRET section)
+5. **Revoke** the old secret at the provider **after** deploy + verification
+   succeed (except where dual-active keys are not possible).
 6. **Record** rotation date in the team password manager / ops log.
+
+## Postgres / DATABASE_URL
+
+Database credentials must **not** be revoked before every instance has the
+new URL. Sequence:
+
+1. Create a new Postgres role/password (or rotate via provider UI) while
+   keeping the old credential active.
+2. Set `DATABASE_URL` to the new credential in Vercel (all environments that
+   hit the DB).
+3. Redeploy **all** app instances and wait for old serverless isolates to
+   drain (or force a full redeploy / wait past idle timeout).
+4. Verify: `curl --fail "$APP_URL/api/health"` reports `database: up`, and a
+   known Prisma-backed page (e.g. bookmarks while signed in) still works.
+5. Only then revoke or drop the old Postgres credential.
+6. Keep an overlap window (recommended ≥ 30 minutes) between step 3 and
+   step 5 so cold starts that still have the old env cannot brick the app.
 
 ## NextAuth secret specifically
 
-Changing `NEXTAUTH_SECRET` invalidates all existing sessions. Prefer rotating
-during low traffic and announce a forced re-login.
+Changing `NEXTAUTH_SECRET` **invalidates all existing sessions**. The site
+stays up, but every user must log in again.
+
+Deployment checklist for this rotation:
+
+- [ ] Announce a forced re-login (prefer low-traffic window)
+- [ ] Deploy with the new `NEXTAUTH_SECRET`
+- [ ] Confirm old session cookies are rejected (open a private window with an
+      old cookie → should be signed out)
+- [ ] Confirm **fresh login succeeds** (password and/or OAuth provider)
+- [ ] Confirm protected routes work after the new login
+- [ ] Revoke any leaked copy of the old secret
 
 ## CACHE_INVALIDATION_SECRET
 
 1. Generate: `openssl rand -hex 32`
 2. Update Vercel env + GitHub Actions secret `CACHE_INVALIDATION_SECRET`
-3. Redeploy app, then re-run ingest workflow to confirm `Bearer` auth works
+3. Redeploy the app
+4. **Direct validation** (must fail the shell on non-2xx — do not use
+   `|| echo "non-fatal"` when validating a rotation):
+
+```bash
+# Expect HTTP 200 (or 2xx). --fail makes curl exit non-zero otherwise.
+curl --fail --silent --show-error \
+  -X POST "${APP_URL}/api/cache/invalidate" \
+  -H "Authorization: Bearer ${CACHE_INVALIDATION_SECRET}" \
+  -H "Content-Type: application/json" \
+  -o /tmp/cache-invalidate-body.json \
+  -w "HTTP %{http_code}\n"
+
+# Optional: reject unexpected bodies
+test -s /tmp/cache-invalidate-body.json
+```
+
+Note: `sync_events.yml` uses `|| echo "Cache invalidation failed (non-fatal)"`
+so a failed invalidate does **not** fail that workflow. That is intentional for
+CI resilience and **must not** be used as proof of a successful secret rotation.
+Always use the direct `curl --fail` check above after rotating this secret.
 
 ## Quarterly checklist
 
-- [ ] Rotate `NEXTAUTH_SECRET` (or confirm still private)
+- [ ] Rotate `NEXTAUTH_SECRET` (or confirm still private) and verify re-login
 - [ ] Rotate Upstash token
 - [ ] Rotate Groq key
 - [ ] Review GitHub PATs and remove unused
@@ -53,6 +109,8 @@ during low traffic and announce a forced re-login.
 If a secret is exposed in a PR, log, or chat:
 
 1. Rotate immediately (do not wait for the quarterly window).
-2. Revoke the old credential first when the provider allows dual-active keys;
-   otherwise rotate then deploy within minutes.
+2. For dual-active providers, rotate then deploy then revoke. For single-active
+   secrets, minimize the window between deploy and revoke.
 3. Open a private security note and audit access logs for the secret’s surface.
+4. For `DATABASE_URL`, never revoke the old password until every deployment has
+   the new URL (see Postgres section).

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,73 @@
+/* ConfScouting service worker (issue #74)
+ * Cache-first for static shell assets; network-first for HTML navigations.
+ * Does not cache authenticated API responses.
+ */
+const CACHE_VERSION = 'confscout-shell-v1';
+const PRECACHE = [
+  '/',
+  '/manifest.json',
+  '/favicon.svg',
+  '/icon.png',
+  '/logo.svg',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then((cache) => cache.addAll(PRECACHE)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_VERSION).map((k) => caches.delete(k)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  // Never cache API / auth / monitoring
+  if (
+    url.pathname.startsWith('/api/') ||
+    url.pathname.startsWith('/monitoring') ||
+    url.pathname.includes('next-auth')
+  ) {
+    return;
+  }
+
+  // Navigations: network first, fall back to cache
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => caches.match(request).then((r) => r || caches.match('/')))
+    );
+    return;
+  }
+
+  // Static assets: cache first
+  if (
+    url.pathname.startsWith('/_next/static/') ||
+    url.pathname.match(/\.(?:js|css|png|jpg|jpeg|svg|webp|woff2?|ico)$/)
+  ) {
+    event.respondWith(
+      caches.match(request).then(
+        (cached) =>
+          cached ||
+          fetch(request).then((response) => {
+            const copy = response.clone();
+            caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+            return response;
+          })
+      )
+    );
+  }
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,10 @@
 /* ConfScouting service worker (issue #74)
  * Cache-first for static shell assets; network-first for HTML navigations.
- * Does not cache authenticated API responses.
+ * Never caches /api, auth, or private/no-store responses.
  */
-const CACHE_VERSION = 'confscout-shell-v1';
-const PRECACHE = [
+const cachePrefix = 'confscout-shell-';
+const cacheVersion = `${cachePrefix}v1`;
+const precache = [
   '/',
   '/manifest.json',
   '/favicon.svg',
@@ -11,17 +12,43 @@ const PRECACHE = [
   '/logo.svg',
 ];
 
+function isCacheableNavigationResponse(response) {
+  if (!response || !response.ok) return false;
+  // Do not store redirects (may carry auth cookies / session paths)
+  if (response.type === 'opaqueredirect' || response.redirected) return false;
+  const cc = (response.headers.get('Cache-Control') || '').toLowerCase();
+  if (cc.includes('private') || cc.includes('no-store') || cc.includes('no-cache')) {
+    return false;
+  }
+  // Only explicit public or default public shell responses
+  if (cc.includes('public') || cc === '') {
+    return true;
+  }
+  return false;
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_VERSION).then((cache) => cache.addAll(PRECACHE)).then(() => self.skipWaiting())
+    caches
+      .open(cacheVersion)
+      .then((cache) => cache.addAll(precache))
+      .then(() => self.skipWaiting())
   );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => k !== CACHE_VERSION).map((k) => caches.delete(k)))
-    ).then(() => self.clients.claim())
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          // Only delete our versioned shell caches — leave unrelated caches alone
+          keys
+            .filter((k) => k.startsWith(cachePrefix) && k !== cacheVersion)
+            .map((k) => caches.delete(k))
+        )
+      )
+      .then(() => self.clients.claim())
   );
 });
 
@@ -30,25 +57,34 @@ self.addEventListener('fetch', (event) => {
   if (request.method !== 'GET') return;
 
   const url = new URL(request.url);
-  // Never cache API / auth / monitoring
+  // Never intercept API / auth / monitoring
   if (
     url.pathname.startsWith('/api/') ||
     url.pathname.startsWith('/monitoring') ||
-    url.pathname.includes('next-auth')
+    url.pathname.includes('next-auth') ||
+    url.pathname.includes('/auth/')
   ) {
     return;
   }
 
-  // Navigations: network first, fall back to cache
+  // Navigations: network first. Cache only public shell HTML.
+  // Fallback uses only the precached public shell ("/") — never a
+  // previously cached authenticated page for another user.
   if (request.mode === 'navigate') {
     event.respondWith(
       fetch(request)
         .then((response) => {
-          const copy = response.clone();
-          caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+          if (isCacheableNavigationResponse(response)) {
+            const copy = response.clone();
+            // Only ever precache the public home shell, not arbitrary URLs
+            // that might reflect account-specific content.
+            if (url.pathname === '/' || url.pathname === '/en') {
+              caches.open(cacheVersion).then((cache) => cache.put('/', copy));
+            }
+          }
           return response;
         })
-        .catch(() => caches.match(request).then((r) => r || caches.match('/')))
+        .catch(() => caches.match('/') )
     );
     return;
   }
@@ -63,8 +99,10 @@ self.addEventListener('fetch', (event) => {
         (cached) =>
           cached ||
           fetch(request).then((response) => {
-            const copy = response.clone();
-            caches.open(CACHE_VERSION).then((cache) => cache.put(request, copy));
+            if (response && response.ok) {
+              const copy = response.clone();
+              caches.open(cacheVersion).then((cache) => cache.put(request, copy));
+            }
             return response;
           })
       )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ requests>=2.28.0
 
 # HTML parsing for web scraping (WikiCFP, etc.)
 beautifulsoup4>=4.11.0
+# Faster HTML parser used when available
+lxml>=4.9.0
 
 # Geocoding for location coordinates
 geopy>=2.3.0

--- a/scripts/fetch_confs.py
+++ b/scripts/fetch_confs.py
@@ -152,8 +152,9 @@ def load_cache():
                         city_cache = json.load(f)
                     print(f"[WARN] Cache corrupted; restored {len(city_cache)} entries from .bak")
                     return
-                except (json.JSONDecodeError, OSError):
-                    pass
+                except (json.JSONDecodeError, OSError) as bak_exc:
+                    # Backup also unreadable; fall through to empty cache.
+                    print(f"[WARN] Cache backup restore failed: {bak_exc}")
             print("[WARN] Cache file corrupted. Starting fresh.")
             city_cache = {}
     else:
@@ -191,10 +192,11 @@ def save_cache():
             os.fsync(f.fileno())
         os.replace(tmp_name, CACHE_PATH)
     except Exception:
+        # Best-effort cleanup of the temp file; ignore if already gone.
         try:
             os.unlink(tmp_name)
-        except OSError:
-            pass
+        except OSError as cleanup_exc:
+            print(f"[WARN] Could not remove temp cache file {tmp_name}: {cleanup_exc}")
         raise
     print(f"[INFO] Saved {len(city_cache)} locations to cache.")
 

--- a/scripts/fetch_confs.py
+++ b/scripts/fetch_confs.py
@@ -107,8 +107,9 @@ FINANCIAL_AID_KEYWORDS = [
     "opportunity grant", "diversity fund", "inclusion"
 ]
 
-# Precomputed lowercase set for O(1) membership (issues #96, #110)
-FINANCIAL_AID_KEYWORDS_SET = frozenset(k.lower() for k in FINANCIAL_AID_KEYWORDS)
+# Ordered lowercase keywords so financialAid.types emission is deterministic
+# (preserves source list order; issues #96 / #110).
+FINANCIAL_AID_KEYWORDS_LOWER = tuple(k.lower() for k in FINANCIAL_AID_KEYWORDS)
 
 
 # Country to continent mapping (common countries)
@@ -266,7 +267,7 @@ def detect_financial_aid(description: str = "", name: str = "") -> dict:
     text = f"{name} {description}".lower()
 
     detected_types = []
-    for keyword in FINANCIAL_AID_KEYWORDS_SET:
+    for keyword in FINANCIAL_AID_KEYWORDS_LOWER:
         if keyword in text:
             if "travel" in keyword:
                 if "travel" not in detected_types:
@@ -500,9 +501,26 @@ def fetch_sessionize_cfps() -> list:
 
     # Parallelize page scrapes (issue #87) with a small worker pool so we stay
     # polite to Sessionize while still finishing faster than pure serial I/O.
+    # Shared throttle gates every worker before hitting Sessionize.
     from concurrent.futures import ThreadPoolExecutor, as_completed
+    import threading
+    import time as _time
 
-    def _scrape_one(url: str):
+    _sessionize_lock = threading.Lock()
+    _sessionize_min_interval = 1.0  # seconds between Sessionize requests
+    _sessionize_last_request = 0.0
+
+    def _sessionize_throttle() -> None:
+        nonlocal _sessionize_last_request
+        with _sessionize_lock:
+            now = _time.monotonic()
+            wait = _sessionize_min_interval - (now - _sessionize_last_request)
+            if wait > 0:
+                _time.sleep(wait)
+            _sessionize_last_request = _time.monotonic()
+
+    def _scrape_one(url: str) -> Optional[dict]:
+        _sessionize_throttle()
         with ConfScoutHTTPClient() as client:
             return scrape_sessionize_cfp_page(url, client)
 
@@ -518,7 +536,7 @@ def fetch_sessionize_cfps() -> list:
                     print(f"  [OK] Scraped: {conf['name']}")
             except (requests.RequestException, ValueError, OSError) as e:
                 print(f"  [FAIL] Failed to scrape {url}: {e}")
-    
+
     print(f"[OK] Fetched {len(conferences)} CFPs from Sessionize")
     return conferences
 

--- a/scripts/fetch_confs.py
+++ b/scripts/fetch_confs.py
@@ -98,6 +98,10 @@ FINANCIAL_AID_KEYWORDS = [
     "opportunity grant", "diversity fund", "inclusion"
 ]
 
+# Precomputed lowercase set for O(1) membership (issues #96, #110)
+FINANCIAL_AID_KEYWORDS_SET = frozenset(k.lower() for k in FINANCIAL_AID_KEYWORDS)
+
+
 # Country to continent mapping (common countries)
 COUNTRY_CONTINENTS = {
     "U.S.A.": "North America", "USA": "North America", "United States": "North America",
@@ -138,10 +142,41 @@ def load_cache():
 
 
 def save_cache():
-    """Save city coordinates cache."""
+    """Save city coordinates cache atomically (issue #205).
+
+    Writes to a temp file then renames over the target so a crash mid-write
+    cannot leave a half-written JSON that corrupts the next run. Also keeps
+    a single rolling .bak of the previous good cache when one exists.
+    """
+    import os
+    import tempfile
+
     CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(CACHE_PATH, 'w', encoding='utf-8') as f:
-        json.dump(city_cache, f, indent=2, ensure_ascii=False)
+    payload = json.dumps(city_cache, indent=2, ensure_ascii=False)
+
+    # Backup previous good cache (best-effort).
+    if CACHE_PATH.exists():
+        bak = CACHE_PATH.with_suffix(CACHE_PATH.suffix + ".bak")
+        try:
+            bak.write_bytes(CACHE_PATH.read_bytes())
+        except OSError as exc:
+            print(f"[WARN] Could not write cache backup: {exc}")
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(CACHE_PATH.parent), prefix=".city_cache.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_name, CACHE_PATH)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
     print(f"[INFO] Saved {len(city_cache)} locations to cache.")
 
 
@@ -210,7 +245,7 @@ def detect_financial_aid(description: str = "", name: str = "") -> dict:
     text = f"{name} {description}".lower()
 
     detected_types = []
-    for keyword in FINANCIAL_AID_KEYWORDS:
+    for keyword in FINANCIAL_AID_KEYWORDS_SET:
         if keyword in text:
             if "travel" in keyword:
                 if "travel" not in detected_types:

--- a/scripts/fetch_confs.py
+++ b/scripts/fetch_confs.py
@@ -20,6 +20,15 @@ from pathlib import Path
 
 import requests
 from bs4 import BeautifulSoup
+
+
+def soup_parser() -> str:
+    """Prefer lxml when installed (issue #104); fall back to html.parser."""
+    try:
+        import lxml  # noqa: F401
+        return "lxml"
+    except ImportError:
+        return "html.parser"
 from dateutil.parser import parse as parse_date
 from geopy.geocoders import Nominatim
 from geopy.exc import GeocoderTimedOut
@@ -135,6 +144,16 @@ def load_cache():
                 city_cache = json.load(f)
             print(f"[INFO] Loaded {len(city_cache)} cached locations.")
         except json.JSONDecodeError:
+            # Prefer rolling backup if present (issue #205 / #206)
+            bak = CACHE_PATH.with_suffix(CACHE_PATH.suffix + ".bak")
+            if bak.exists():
+                try:
+                    with open(bak, 'r', encoding='utf-8') as f:
+                        city_cache = json.load(f)
+                    print(f"[WARN] Cache corrupted; restored {len(city_cache)} entries from .bak")
+                    return
+                except (json.JSONDecodeError, OSError):
+                    pass
             print("[WARN] Cache file corrupted. Starting fresh.")
             city_cache = {}
     else:
@@ -342,22 +361,39 @@ def fetch_confs_tech_data() -> list:
         "networking", "performance", "testing", "opensource", "leadership", "product"
     ]
 
-    # Use GitHub-optimized HTTP client with proper User-Agent
-    with GitHubHTTPClient() as client:
-        for year in years:
-            for topic in topics:
-                url = f"{GITHUB_BASE_URL}/{year}/{topic}.json"
-                try:
-                    # Use client with retry logic and proper User-Agent
-                    response = client.get_with_retry(url, max_retries=3, timeout=10)
-                    data = response.json()
-                    for conf in data:
-                        conferences.append(parse_confs_tech_entry(conf, topic))
-                    print(f"[OK] Fetched {len(data)} conferences from {year}/{topic}.json")
-                except requests.RequestException as e:
-                    print(f"[FAIL] Failed to fetch {url}: {e}")
-                except json.JSONDecodeError:
-                    print(f"[FAIL] Invalid JSON in {url}")
+    # Parallel fetch of year×topic JSON files (issue #86). Each worker owns its
+    # own HTTP client so connection state stays thread-local.
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    jobs = [
+        (year, topic, f"{GITHUB_BASE_URL}/{year}/{topic}.json")
+        for year in years
+        for topic in topics
+    ]
+
+    def _fetch_topic(year: int, topic: str, url: str) -> list:
+        with GitHubHTTPClient() as client:
+            response = client.get_with_retry(url, max_retries=3, timeout=10)
+            data = response.json()
+            parsed = [parse_confs_tech_entry(conf, topic) for conf in data]
+            print(f"[OK] Fetched {len(data)} conferences from {year}/{topic}.json")
+            return parsed
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {
+            pool.submit(_fetch_topic, year, topic, url): (year, topic, url)
+            for year, topic, url in jobs
+        }
+        for fut in as_completed(futures):
+            year, topic, url = futures[fut]
+            try:
+                conferences.extend(fut.result())
+            except requests.RequestException as e:
+                print(f"[FAIL] Failed to fetch {url}: {e}")
+            except json.JSONDecodeError:
+                print(f"[FAIL] Invalid JSON in {url}")
+            except Exception as e:
+                print(f"[FAIL] Unexpected error for {url}: {e}")
 
     return conferences
 
@@ -499,7 +535,7 @@ def scrape_sessionize_cfp_page(url: str, client: ConfScoutHTTPClient) -> Optiona
     if response.status_code != 200:
         return None
     
-    soup = BeautifulSoup(response.text, 'html.parser')
+    soup = BeautifulSoup(response.text, soup_parser())
     
     # Extract event name from ibox-title container
     title_box = soup.find(class_="ibox-title")

--- a/scripts/fetch_confs.py
+++ b/scripts/fetch_confs.py
@@ -460,14 +460,25 @@ def fetch_sessionize_cfps() -> list:
     
     print(f"[INFO] Sessionize: Scraping {len(SESSIONIZE_CFPS)} known CFP pages...")
 
-    with ConfScoutHTTPClient() as client:
-        for url in SESSIONIZE_CFPS:
+    # Parallelize page scrapes (issue #87) with a small worker pool so we stay
+    # polite to Sessionize while still finishing faster than pure serial I/O.
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    def _scrape_one(url: str):
+        with ConfScoutHTTPClient() as client:
+            return scrape_sessionize_cfp_page(url, client)
+
+    max_workers = min(4, len(SESSIONIZE_CFPS))
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_scrape_one, url): url for url in SESSIONIZE_CFPS}
+        for fut in as_completed(futures):
+            url = futures[fut]
             try:
-                conf = scrape_sessionize_cfp_page(url, client)
+                conf = fut.result()
                 if conf:
                     conferences.append(conf)
                     print(f"  [OK] Scraped: {conf['name']}")
-            except (requests.RequestException, ValueError) as e:
+            except (requests.RequestException, ValueError, OSError) as e:
                 print(f"  [FAIL] Failed to scrape {url}: {e}")
     
     print(f"[OK] Fetched {len(conferences)} CFPs from Sessionize")

--- a/scripts/sources/papercall.py
+++ b/scripts/sources/papercall.py
@@ -7,6 +7,7 @@ Method: BeautifulSoup HTML parsing
 
 import requests
 from bs4 import BeautifulSoup
+from importlib.util import find_spec
 from typing import Optional
 import re
 
@@ -21,7 +22,8 @@ def fetch() -> list[dict]:
     try:
         response = requests.get(PAPERCALL_URL, timeout=30)
         response.raise_for_status()
-        soup = BeautifulSoup(response.text, "lxml" if __import__("importlib").util.find_spec("lxml") else "html.parser")
+        parser = "lxml" if find_spec("lxml") else "html.parser"
+        soup = BeautifulSoup(response.text, parser)
         
         # Find event cards
         event_links = soup.find_all("a", href=re.compile(r"^/[a-z0-9-]+$"))

--- a/scripts/sources/papercall.py
+++ b/scripts/sources/papercall.py
@@ -21,7 +21,7 @@ def fetch() -> list[dict]:
     try:
         response = requests.get(PAPERCALL_URL, timeout=30)
         response.raise_for_status()
-        soup = BeautifulSoup(response.text, "html.parser")
+        soup = BeautifulSoup(response.text, "lxml" if __import__("importlib").util.find_spec("lxml") else "html.parser")
         
         # Find event cards
         event_links = soup.find_all("a", href=re.compile(r"^/[a-z0-9-]+$"))

--- a/scripts/sources/wikicfp.py
+++ b/scripts/sources/wikicfp.py
@@ -10,6 +10,7 @@ Based on http://www.wikicfp.com/cfp/allcat showing 9000+ CFPs per major category
 
 import requests
 from bs4 import BeautifulSoup
+from importlib.util import find_spec
 from typing import List, Dict, Optional
 import re
 from datetime import datetime
@@ -114,7 +115,8 @@ def _fetch_category(category: str, domain: str) -> List[Dict]:
             print(f"[wikicfp] Page {page} failed for {category}: {e}")
             break
         
-        soup = BeautifulSoup(response.text, "lxml" if __import__("importlib").util.find_spec("lxml") else "html.parser")
+        parser = "lxml" if find_spec("lxml") else "html.parser"
+        soup = BeautifulSoup(response.text, parser)
         
         # Find conference table rows
         page_confs = _parse_conference_list(soup, category, domain)

--- a/scripts/sources/wikicfp.py
+++ b/scripts/sources/wikicfp.py
@@ -114,7 +114,7 @@ def _fetch_category(category: str, domain: str) -> List[Dict]:
             print(f"[wikicfp] Page {page} failed for {category}: {e}")
             break
         
-        soup = BeautifulSoup(response.text, "html.parser")
+        soup = BeautifulSoup(response.text, "lxml" if __import__("importlib").util.find_spec("lxml") else "html.parser")
         
         # Find conference table rows
         page_confs = _parse_conference_list(soup, category, domain)

--- a/scripts/utils/geocoder.py
+++ b/scripts/utils/geocoder.py
@@ -229,8 +229,9 @@ class GeocodeCache:
                 bak = self.cache_file.with_suffix(self.cache_file.suffix + ".bak")
                 try:
                     bak.write_bytes(self.cache_file.read_bytes())
-                except OSError:
-                    pass
+                except OSError as bak_exc:
+                    # Backup is best-effort; continue with the atomic write.
+                    print(f"[WARN] Could not write geocode cache backup: {bak_exc}")
 
             fd, tmp_name = tempfile.mkstemp(
                 dir=str(self.cache_file.parent),
@@ -244,13 +245,15 @@ class GeocodeCache:
                     os.fsync(f.fileno())
                 os.replace(tmp_name, self.cache_file)
             except Exception:
+                # Best-effort cleanup of the temp file; ignore if already gone.
                 try:
                     os.unlink(tmp_name)
-                except OSError:
-                    pass
+                except OSError as cleanup_exc:
+                    print(f"[WARN] Could not remove temp cache file {tmp_name}: {cleanup_exc}")
                 raise
             return True
-        except (IOError, OSError):
+        except (IOError, OSError) as save_exc:
+            print(f"[WARN] Geocode cache save failed: {save_exc}")
             return False
     
     def get(self, key: str) -> Optional[Tuple[float, float]]:

--- a/scripts/utils/geocoder.py
+++ b/scripts/utils/geocoder.py
@@ -217,12 +217,40 @@ class GeocodeCache:
         return {}
     
     def _save_cache(self) -> bool:
+        """Atomic write + rolling .bak (issue #205) to avoid corrupt JSON."""
+        import os
+        import tempfile
+
         try:
             self.cache_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.cache_file, 'w', encoding='utf-8') as f:
-                json.dump(self.cache, f, indent=2, ensure_ascii=False)
+            payload = json.dumps(self.cache, indent=2, ensure_ascii=False)
+
+            if self.cache_file.exists():
+                bak = self.cache_file.with_suffix(self.cache_file.suffix + ".bak")
+                try:
+                    bak.write_bytes(self.cache_file.read_bytes())
+                except OSError:
+                    pass
+
+            fd, tmp_name = tempfile.mkstemp(
+                dir=str(self.cache_file.parent),
+                prefix=".city_cache.",
+                suffix=".tmp",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(payload)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_name, self.cache_file)
+            except Exception:
+                try:
+                    os.unlink(tmp_name)
+                except OSError:
+                    pass
+                raise
             return True
-        except IOError:
+        except (IOError, OSError):
             return False
     
     def get(self, key: str) -> Optional[Tuple[float, float]]:

--- a/scripts/utils/geocoder.py
+++ b/scripts/utils/geocoder.py
@@ -208,12 +208,25 @@ class GeocodeCache:
         self.cache = self._load_cache()
     
     def _load_cache(self) -> dict:
+        """Load primary cache; fall back to rolling .bak when primary is bad."""
+        bak = self.cache_file.with_suffix(self.cache_file.suffix + ".bak")
+
         if self.cache_file.exists():
             try:
                 with open(self.cache_file, 'r', encoding='utf-8') as f:
                     return json.load(f)
-            except (json.JSONDecodeError, IOError):
-                return {}
+            except (json.JSONDecodeError, IOError) as primary_exc:
+                print(f"[WARN] Primary geocode cache unreadable: {primary_exc}")
+
+        if bak.exists():
+            try:
+                with open(bak, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                print(f"[WARN] Restored geocode cache from {bak.name} ({len(data)} entries)")
+                return data
+            except (json.JSONDecodeError, IOError) as bak_exc:
+                print(f"[WARN] Geocode cache backup unreadable: {bak_exc}")
+
         return {}
     
     def _save_cache(self) -> bool:

--- a/src/app/[locale]/compare/page.tsx
+++ b/src/app/[locale]/compare/page.tsx
@@ -1,22 +1,202 @@
 'use client';
+
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams, useRouter, useParams } from 'next/navigation';
 import { useCompare } from '@/context/CompareContext';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import Link from 'next/link';
+import ShareButtons from '@/components/ShareButtons';
+import type { Conference } from '@/types/conference';
+import { isValidConference } from '@/lib/validation';
 
-export default function ComparePage() {
-  const { selectedConferences, removeFromCompare } = useCompare();
+/**
+ * Side-by-side comparison with shareable `?ids=` deep link (issue #78).
+ */
+function CompareContent() {
+  const { selectedConferences, removeFromCompare, addToCompare, clearCompare } = useCompare();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const params = useParams();
+  const locale = (params.locale as string) || 'en';
+  const [hydratedFromUrl, setHydratedFromUrl] = useState(false);
+
+  // Hydrate compare list from ?ids= once on mount when empty.
+  useEffect(() => {
+    if (hydratedFromUrl) return;
+    const idsParam = searchParams.get('ids');
+    if (!idsParam || selectedConferences.length > 0) {
+      setHydratedFromUrl(true);
+      return;
+    }
+
+    const ids = idsParam.split(',').map((s) => s.trim()).filter(Boolean).slice(0, 4);
+    if (ids.length === 0) {
+      setHydratedFromUrl(true);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/data/conferences.json');
+        if (!res.ok) return;
+        const data = await res.json();
+        const all: Conference[] = Object.values(data.months || {}).flat() as Conference[];
+        const byId = new Map(all.map((c) => [c.id, c]));
+        for (const id of ids) {
+          if (cancelled) return;
+          const conf = byId.get(id);
+          if (conf && isValidConference(conf)) {
+            addToCompare(conf);
+          }
+        }
+      } finally {
+        if (!cancelled) setHydratedFromUrl(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams, selectedConferences.length, addToCompare, hydratedFromUrl]);
+
+  // Keep URL in sync for shareable comparisons
+  useEffect(() => {
+    if (!hydratedFromUrl) return;
+    const ids = selectedConferences.map((c) => c.id).join(',');
+    const next = ids
+      ? `/${locale}/compare?ids=${encodeURIComponent(ids)}`
+      : `/${locale}/compare`;
+    router.replace(next, { scroll: false });
+  }, [selectedConferences, locale, router, hydratedFromUrl]);
+
+  const shareUrl =
+    typeof window !== 'undefined'
+      ? window.location.href
+      : `https://www.confscouting.com/${locale}/compare`;
+
+  const copyShareLink = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const rows = useMemo(
+    () => [
+      {
+        label: 'Date',
+        render: (c: Conference) =>
+          c.startDate
+            ? `${c.startDate}${c.endDate && c.endDate !== c.startDate ? ` → ${c.endDate}` : ''}`
+            : 'TBD',
+      },
+      {
+        label: 'Location',
+        render: (c: Conference) => c.location?.raw || (c.online ? 'Online' : 'TBD'),
+      },
+      {
+        label: 'Domain',
+        render: (c: Conference) => c.domain,
+      },
+      {
+        label: 'Online',
+        render: (c: Conference) => (c.online ? 'Yes' : 'No'),
+      },
+      {
+        label: 'CFP Status',
+        render: (c: Conference) =>
+          c.cfp?.status === 'open'
+            ? `Open${typeof c.cfp.daysRemaining === 'number' ? ` (${c.cfp.daysRemaining}d left)` : ''}`
+            : c.cfp?.status === 'closed'
+              ? 'Closed'
+              : 'N/A',
+      },
+      {
+        label: 'CFP Deadline',
+        render: (c: Conference) => c.cfp?.endDate || '—',
+      },
+      {
+        label: 'CFP URL',
+        render: (c: Conference) =>
+          c.cfp?.url ? (
+            <a
+              href={c.cfp.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:underline"
+            >
+              Open CFP
+            </a>
+          ) : (
+            '—'
+          ),
+      },
+      {
+        label: 'Financial aid',
+        render: (c: Conference) => (c.financialAid?.available ? 'Available' : 'Not listed'),
+      },
+      {
+        label: 'Tags',
+        render: (c: Conference) => (c.tags?.length ? c.tags.slice(0, 6).join(', ') : '—'),
+      },
+      {
+        label: 'Website',
+        render: (c: Conference) => (
+          <a
+            href={c.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-400 hover:text-blue-300 hover:underline"
+          >
+            Visit website
+          </a>
+        ),
+      },
+    ],
+    []
+  );
 
   return (
     <div className="min-h-screen bg-black">
       <Header />
       <main className="max-w-7xl mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-white mb-8">Compare Conferences</h1>
-        
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+          <h1 className="text-3xl font-bold text-white">Compare Conferences</h1>
+          {selectedConferences.length > 0 && (
+            <div className="flex items-center gap-3">
+              <ShareButtons
+                url={shareUrl}
+                title="Conference comparison on ConfScouting"
+                text={`Comparing ${selectedConferences.map((c) => c.name).join(', ')}`}
+              />
+              <button
+                type="button"
+                onClick={() => void copyShareLink()}
+                className="text-sm text-zinc-400 hover:text-white underline-offset-2 hover:underline"
+              >
+                Copy compare link
+              </button>
+              <button
+                type="button"
+                onClick={clearCompare}
+                className="text-sm text-red-400/90 hover:text-red-300"
+              >
+                Clear all
+              </button>
+            </div>
+          )}
+        </div>
+
         {selectedConferences.length === 0 ? (
           <div className="text-center py-12 text-zinc-500">
             <p>No conferences selected to compare.</p>
-            <Link href="/" className="bg-blue-600 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded mt-4 inline-block transition-colors">
+            <Link
+              href={`/${locale}`}
+              className="bg-blue-600 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded mt-4 inline-block transition-colors"
+            >
               Browse Conferences
             </Link>
           </div>
@@ -26,13 +206,13 @@ export default function ComparePage() {
               <thead>
                 <tr>
                   <th className="p-4 border-b border-zinc-800 text-zinc-400 w-32">Feature</th>
-                  {selectedConferences.map(c => (
+                  {selectedConferences.map((c) => (
                     <th key={c.id} className="p-4 border-b border-zinc-800 min-w-[200px]">
                       <div className="flex justify-between items-start gap-2">
                         <span className="text-white font-bold text-lg">{c.name}</span>
-                        <button 
+                        <button
                           type="button"
-                          onClick={() => removeFromCompare(c.id)} 
+                          onClick={() => removeFromCompare(c.id)}
                           aria-label={`Remove ${c.name} from comparison`}
                           className="text-zinc-400 hover:text-red-400 text-xl leading-none"
                           title="Remove"
@@ -45,62 +225,18 @@ export default function ComparePage() {
                 </tr>
               </thead>
               <tbody className="text-zinc-300">
-                <tr>
-                  <td className="p-4 border-b border-zinc-800 font-medium text-zinc-500">Date</td>
-                  {selectedConferences.map(c => (
-                    <td key={c.id} className="p-4 border-b border-zinc-800">
-                      {c.startDate || 'TBD'}
+                {rows.map((row) => (
+                  <tr key={row.label}>
+                    <td className="p-4 border-b border-zinc-800 font-medium text-zinc-500">
+                      {row.label}
                     </td>
-                  ))}
-                </tr>
-                <tr>
-                  <td className="p-4 border-b border-zinc-800 font-medium text-zinc-500">Location</td>
-                  {selectedConferences.map(c => (
-                    <td key={c.id} className="p-4 border-b border-zinc-800">
-                      {c.location?.raw || (c.online ? 'Online' : 'TBD')}
-                    </td>
-                  ))}
-                </tr>
-                <tr>
-                  <td className="p-4 border-b border-zinc-800 font-medium text-zinc-500">Domain</td>
-                  {selectedConferences.map(c => (
-                    <td key={c.id} className="p-4 border-b border-zinc-800 capitalize">
-                      <span className="inline-block px-2 py-1 rounded-full bg-zinc-800 text-xs">
-                        {c.domain}
-                      </span>
-                    </td>
-                  ))}
-                </tr>
-                <tr>
-                  <td className="p-4 border-b border-zinc-800 font-medium text-zinc-500">Online</td>
-                  {selectedConferences.map(c => (
-                    <td key={c.id} className="p-4 border-b border-zinc-800">
-                      {c.online ? 'Yes' : 'No'}
-                    </td>
-                  ))}
-                </tr>
-                <tr>
-                  <td className="p-4 border-b border-zinc-800 font-medium text-zinc-500">CFP Status</td>
-                  {selectedConferences.map(c => (
-                    <td key={c.id} className="p-4 border-b border-zinc-800">
-                      {c.cfp?.status === 'open' ? (
-                        <span className="text-green-400 font-medium">Open ({c.cfp.daysRemaining} days left)</span>
-                      ) : (
-                        <span className="text-zinc-500">Closed</span>
-                      )}
-                    </td>
-                  ))}
-                </tr>
-                 <tr>
-                  <td className="p-4 border-b border-zinc-800 font-medium text-zinc-500">Website</td>
-                  {selectedConferences.map(c => (
-                    <td key={c.id} className="p-4 border-b border-zinc-800">
-                      <a href={c.url} target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 hover:underline">
-                        Visit Website
-                      </a>
-                    </td>
-                  ))}
-                </tr>
+                    {selectedConferences.map((c) => (
+                      <td key={c.id} className="p-4 border-b border-zinc-800 capitalize">
+                        {row.render(c)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
@@ -108,5 +244,24 @@ export default function ComparePage() {
       </main>
       <Footer />
     </div>
+  );
+}
+
+export default function ComparePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-black">
+          <Header />
+          <main className="max-w-7xl mx-auto px-4 py-8">
+            <h1 className="text-3xl font-bold text-white mb-8">Compare Conferences</h1>
+            <p className="text-zinc-500">Loading comparison…</p>
+          </main>
+          <Footer />
+        </div>
+      }
+    >
+      <CompareContent />
+    </Suspense>
   );
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -70,10 +70,16 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-blue-600 focus:text-white focus:px-4 focus:py-2 focus:rounded-md"
+        >
+          Skip to content
+        </a>
         <NextIntlClientProvider messages={messages}>
           <SessionProvider>
             <CompareProvider>
-              {children}
+              <div id="main-content">{children}</div>
               <CompareBar />
             </CompareProvider>
           </SessionProvider>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import { CompareProvider } from '@/context/CompareContext';
 import CompareBar from '@/components/CompareBar';
+import ServiceWorkerRegister from '@/components/ServiceWorkerRegister';
 import "../globals.css";
 
 const geistSans = Geist({
@@ -77,6 +78,7 @@ export default async function RootLayout({
             </CompareProvider>
           </SessionProvider>
         </NextIntlClientProvider>
+        <ServiceWorkerRegister />
         <Analytics />
       </body>
     </html>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -79,7 +79,7 @@ export default async function RootLayout({
         <NextIntlClientProvider messages={messages}>
           <SessionProvider>
             <CompareProvider>
-              <div id="main-content">{children}</div>
+              <div id="main-content" tabIndex={-1}>{children}</div>
               <CompareBar />
             </CompareProvider>
           </SessionProvider>

--- a/src/app/[locale]/search/page.tsx
+++ b/src/app/[locale]/search/page.tsx
@@ -1,17 +1,31 @@
 'use client';
 
-import { useState, useEffect, useMemo, useDeferredValue, Suspense } from 'react';
+import { useState, useEffect, useMemo, useDeferredValue, Suspense, useCallback } from 'react';
 import { useSearchParams, useRouter, useParams } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import { type ConferenceData, type SortOption, DOMAIN_INFO } from '@/types/conference';
 
 import Header from '@/components/Header';
 import ConferenceCard from '@/components/ConferenceCard';
 import Footer from '@/components/Footer';
+import { secureFetch } from '@/lib/api';
+
+interface SavedSearchRow {
+  id: string;
+  name: string;
+  filters: {
+    q?: string;
+    domain?: string;
+    cfp?: boolean;
+    sortBy?: string;
+  };
+}
 
 function SearchContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const params = useParams();
+  const { status: authStatus } = useSession();
 
   const [data, setData] = useState<ConferenceData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -30,9 +44,93 @@ function SearchContent() {
   // filter+sort is scheduled at lower priority.
   const deferredSearchTerm = useDeferredValue(searchTerm);
 
+  // Saved searches (issue #56)
+  const [savedSearches, setSavedSearches] = useState<SavedSearchRow[]>([]);
+  const [saveName, setSaveName] = useState('');
+  const [saveBusy, setSaveBusy] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<string | null>(null);
+
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);
   const conferencesPerPage = 12;
+
+  const loadSavedSearches = useCallback(async () => {
+    if (authStatus !== 'authenticated') {
+      setSavedSearches([]);
+      return;
+    }
+    try {
+      const res = await secureFetch('/api/user/saved-searches');
+      if (!res.ok) return;
+      const json = await res.json();
+      setSavedSearches(Array.isArray(json.data) ? json.data : []);
+    } catch {
+      // non-fatal
+    }
+  }, [authStatus]);
+
+  useEffect(() => {
+    void loadSavedSearches();
+  }, [loadSavedSearches]);
+
+  const applySavedSearch = (row: SavedSearchRow) => {
+    const f = row.filters || {};
+    setSearchTerm(f.q || '');
+    setSelectedDomain(f.domain || 'all');
+    setShowCfpOnly(Boolean(f.cfp));
+    if (f.sortBy) setSortBy(f.sortBy as SortOption);
+    setCurrentPage(1);
+  };
+
+  const handleSaveSearch = async () => {
+    const name = saveName.trim();
+    if (!name) {
+      setSaveMsg('Enter a name for this search');
+      return;
+    }
+    setSaveBusy(true);
+    setSaveMsg(null);
+    try {
+      const res = await secureFetch('/api/user/saved-searches', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          filters: {
+            q: searchTerm || undefined,
+            domain: selectedDomain !== 'all' ? selectedDomain : undefined,
+            cfp: showCfpOnly || undefined,
+            sortBy: sortBy !== 'startDate' ? sortBy : undefined,
+          },
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setSaveMsg(json?.error?.message || json?.error || 'Could not save search');
+        return;
+      }
+      setSaveName('');
+      setSaveMsg('Saved');
+      await loadSavedSearches();
+    } catch {
+      setSaveMsg('Could not save search');
+    } finally {
+      setSaveBusy(false);
+    }
+  };
+
+  const handleDeleteSaved = async (id: string) => {
+    try {
+      const res = await secureFetch(`/api/user/saved-searches?id=${encodeURIComponent(id)}`, {
+        method: 'DELETE',
+      });
+      if (res.ok) {
+        setSavedSearches((prev) => prev.filter((s) => s.id !== id));
+      }
+    } catch {
+      // ignore
+    }
+  };
 
   useEffect(() => {
     const loadData = async () => {
@@ -274,6 +372,64 @@ function SearchContent() {
               {filteredConferences.length} result{filteredConferences.length !== 1 ? 's' : ''}
             </div>
           </div>
+
+          {/* Saved searches (#56) — signed-in users only */}
+          {authStatus === 'authenticated' && (
+            <div className="mt-4 pt-4 border-t border-zinc-800/80">
+              <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+                <label htmlFor="save-search-name" className="sr-only">
+                  Name for saved search
+                </label>
+                <input
+                  id="save-search-name"
+                  type="text"
+                  maxLength={80}
+                  placeholder="Name this search…"
+                  value={saveName}
+                  onChange={(e) => setSaveName(e.target.value)}
+                  className="flex-1"
+                />
+                <button
+                  type="button"
+                  onClick={() => void handleSaveSearch()}
+                  disabled={saveBusy}
+                  className="btn-primary whitespace-nowrap disabled:opacity-50"
+                >
+                  {saveBusy ? 'Saving…' : 'Save search'}
+                </button>
+              </div>
+              {saveMsg && (
+                <p className="text-xs text-zinc-400 mt-2" role="status">
+                  {saveMsg}
+                </p>
+              )}
+              {savedSearches.length > 0 && (
+                <ul className="flex flex-wrap gap-2 mt-3">
+                  {savedSearches.map((row) => (
+                    <li key={row.id}>
+                      <span className="inline-flex items-center gap-1 rounded-full border border-zinc-700 bg-zinc-900/60 pl-3 pr-1 py-1 text-xs text-zinc-200">
+                        <button
+                          type="button"
+                          onClick={() => applySavedSearch(row)}
+                          className="hover:text-white"
+                        >
+                          {row.name}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => void handleDeleteSaved(row.id)}
+                          aria-label={`Delete saved search ${row.name}`}
+                          className="ml-1 rounded-full px-1.5 py-0.5 text-zinc-500 hover:text-red-400 hover:bg-zinc-800"
+                        >
+                          ×
+                        </button>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
         </section>
 
         {/* Results */}

--- a/src/app/[locale]/search/page.tsx
+++ b/src/app/[locale]/search/page.tsx
@@ -43,6 +43,7 @@ function SearchContent() {
   // Keeps the input painting instantly while the (thousands-of-rows)
   // filter+sort is scheduled at lower priority.
   const deferredSearchTerm = useDeferredValue(searchTerm);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
 
   // Saved searches (issue #56)
   const [savedSearches, setSavedSearches] = useState<SavedSearchRow[]>([]);
@@ -147,6 +148,33 @@ function SearchContent() {
     };
     loadData();
   }, []);
+
+  // Autocomplete suggestions (issue #75)
+  useEffect(() => {
+    const q = deferredSearchTerm.trim();
+    if (q.length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    let cancelled = false;
+    const t = window.setTimeout(() => {
+      void fetch(`/api/search/suggest?q=${encodeURIComponent(q)}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((json) => {
+          if (cancelled || !json?.data) return;
+          const names: string[] = json.data.conferences || [];
+          const tags: string[] = json.data.tags || [];
+          setSuggestions([...names, ...tags.map((t: string) => `#${t}`)].slice(0, 8));
+        })
+        .catch(() => {
+          if (!cancelled) setSuggestions([]);
+        });
+    }, 200);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(t);
+    };
+  }, [deferredSearchTerm]);
 
   // Flatten conferences from months
   const allConferences = useMemo(() => {
@@ -318,7 +346,14 @@ function SearchContent() {
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="w-full"
+                list="search-suggestions"
+                autoComplete="off"
               />
+              <datalist id="search-suggestions">
+                {suggestions.map((s) => (
+                  <option key={s} value={s.replace(/^#/, '')} />
+                ))}
+              </datalist>
             </div>
 
             {/* Domain */}

--- a/src/app/[locale]/search/page.tsx
+++ b/src/app/[locale]/search/page.tsx
@@ -79,7 +79,8 @@ function SearchContent() {
     setSearchTerm(f.q || '');
     setSelectedDomain(f.domain || 'all');
     setShowCfpOnly(Boolean(f.cfp));
-    if (f.sortBy) setSortBy(f.sortBy as SortOption);
+    // Always reset sort from saved filters (default startDate when omitted)
+    setSortBy((f.sortBy as SortOption) || 'startDate');
     setCurrentPage(1);
   };
 

--- a/src/app/api/conferences/related/route.ts
+++ b/src/app/api/conferences/related/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCachedConferences } from '@/lib/cache';
+import { withErrorHandling, Errors } from '@/lib/errorHandler';
+import type { Conference } from '@/types/conference';
+import type { ApiResponse } from '@/types/api';
+
+/**
+ * GET /api/conferences/related?id=...&limit=6
+ * Related conferences by shared domain/tags (issue #70) — no vector DB required.
+ */
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const id = request.nextUrl.searchParams.get('id');
+  const limit = Math.min(
+    12,
+    Math.max(1, Number(request.nextUrl.searchParams.get('limit') || 6) || 6)
+  );
+
+  if (!id || id.length > 120) {
+    throw Errors.validation('Conference id is required');
+  }
+
+  const data = await getCachedConferences();
+  const all = Object.values(data.months).flat() as Conference[];
+  const source = all.find((c) => c.id === id);
+  if (!source) {
+    throw Errors.notFound('Conference not found');
+  }
+
+  const sourceTags = new Set((source.tags || []).map((t) => t.toLowerCase()));
+
+  const scored = all
+    .filter((c) => c.id !== source.id)
+    .map((c) => {
+      let score = 0;
+      if (c.domain && c.domain === source.domain) score += 3;
+      for (const t of c.tags || []) {
+        if (sourceTags.has(t.toLowerCase())) score += 1;
+      }
+      if (c.cfp?.status === 'open') score += 1;
+      // Prefer upcoming
+      if (c.startDate && source.startDate && c.startDate >= source.startDate.slice(0, 7)) {
+        score += 0.5;
+      }
+      return { conf: c, score };
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((x) => x.conf);
+
+  const response: ApiResponse = {
+    success: true,
+    data: scored,
+    meta: { timestamp: new Date().toISOString() },
+  };
+  return NextResponse.json(response);
+});

--- a/src/app/api/conferences/related/route.ts
+++ b/src/app/api/conferences/related/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCachedConferences } from '@/lib/cache';
 import { withErrorHandling, Errors } from '@/lib/errorHandler';
+import { querySchemas } from '@/lib/apiSchemas';
 import type { Conference } from '@/types/conference';
 import type { ApiResponse } from '@/types/api';
 
@@ -9,15 +10,10 @@ import type { ApiResponse } from '@/types/api';
  * Related conferences by shared domain/tags (issue #70) — no vector DB required.
  */
 export const GET = withErrorHandling(async (request: NextRequest) => {
-  const id = request.nextUrl.searchParams.get('id');
-  const limit = Math.min(
-    12,
-    Math.max(1, Number(request.nextUrl.searchParams.get('limit') || 6) || 6)
-  );
-
-  if (!id || id.length > 120) {
-    throw Errors.validation('Conference id is required');
-  }
+  const { id, limit } = querySchemas.relatedConferences.parse({
+    id: request.nextUrl.searchParams.get('id') ?? undefined,
+    limit: request.nextUrl.searchParams.get('limit') ?? undefined,
+  });
 
   const data = await getCachedConferences();
   const all = Object.values(data.months).flat() as Conference[];

--- a/src/app/api/conferences/route.ts
+++ b/src/app/api/conferences/route.ts
@@ -9,6 +9,7 @@ import { querySchemas } from '@/lib/apiSchemas';
 import { withErrorHandling } from '@/lib/errorHandler';
 import { ApiResponse } from '@/types/api';
 import { Prisma } from '@prisma/client';
+import { createHash } from 'crypto';
 import { getLocalMonthYear } from '@/lib/date';
 
 /**
@@ -85,8 +86,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   const skip = (page - 1) * limit;
   const userId = session?.user?.id;
 
-  // Attendance: use `_count` for totals (issue #84) and a tiny preview
-  // relation (take 5) instead of loading full attendance rows just to count.
+  // Attendance: use `_count` for totals (issue #84). Preview avatars only
+  // for authenticated viewers — anonymous responses never expose names/images.
   // isAttending is resolved with a single batched query for the page of IDs.
   const [conferences, total] = await Promise.all([
     prisma.conference.findMany({
@@ -112,13 +113,17 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         tags: true,
         financialAid: true,
         _count: { select: { attendances: true } },
-        attendances: {
-          select: {
-            user: { select: { image: true, name: true } },
-          },
-          take: 5,
-          orderBy: { createdAt: 'desc' },
-        },
+        ...(userId
+          ? {
+              attendances: {
+                select: {
+                  user: { select: { image: true, name: true } },
+                },
+                take: 5,
+                orderBy: { createdAt: 'desc' as const },
+              },
+            }
+          : {}),
       },
       orderBy: { startDate: 'asc' },
       skip,
@@ -147,7 +152,14 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   let withOpenCFP = 0;
   let withLocation = 0;
 
+  type AttendancePreview = {
+    user: { image: string | null; name: string | null };
+  };
+
   const formattedConferences = conferences.map((c) => {
+    const previews: AttendancePreview[] = userId
+      ? (((c as unknown as { attendances?: AttendancePreview[] }).attendances) ?? [])
+      : [];
     return {
       id: c.id,
       name: c.name,
@@ -174,11 +186,15 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       // Prisma Json fields are already plain JS values.
       financialAid: (c.financialAid ?? undefined) as Conference['financialAid'],
       attendeeCount: c._count.attendances,
-      isAttending: userId ? attendingSet.has(c.id) : false,
-      attendees: c.attendances.map((a) => ({
-        image: a.user.image,
-        name: a.user.name,
-      })),
+      ...(userId
+        ? {
+            isAttending: attendingSet.has(c.id),
+            attendees: previews.map((a) => ({
+              image: a.user.image,
+              name: a.user.name,
+            })),
+          }
+        : {}),
     };
   });
 
@@ -216,9 +232,24 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     }
   };
 
-  // Weak ETag from page fingerprint (issue #131) — clients can revalidate cheaply.
-  const etagSource = `${total}:${page}:${limit}:${domain ?? ''}:${search ?? ''}:${cfpOnly}:${formattedConferences.map((c) => c.id).join(',')}`;
-  const etag = `"c-${Buffer.from(etagSource).toString('base64url').slice(0, 27)}"`;
+  // Stronger fingerprint: hash full id list + personalization (user + attendance)
+  // so truncated base64 cannot ignore trailing IDs and account switches cannot 304.
+  const attendanceFingerprint = userId
+    ? formattedConferences
+        .map((c) => `${c.id}:${c.isAttending ? 1 : 0}:${c.attendeeCount}`)
+        .join(',')
+    : formattedConferences.map((c) => c.id).join(',');
+  const etagSource = [
+    total,
+    page,
+    limit,
+    domain ?? '',
+    search ?? '',
+    cfpOnly,
+    userId ?? 'anon',
+    attendanceFingerprint,
+  ].join('|');
+  const etag = `"c-${createHash('sha256').update(etagSource).digest('base64url').slice(0, 27)}"`;
   const ifNoneMatch = request.headers.get('if-none-match');
   if (ifNoneMatch && ifNoneMatch === etag) {
     return new NextResponse(null, {
@@ -226,6 +257,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       headers: {
         ETag: etag,
         'Cache-Control': 'private, max-age=30, stale-while-revalidate=60',
+        Vary: 'Cookie',
       },
     });
   }
@@ -234,6 +266,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     headers: {
       ETag: etag,
       'Cache-Control': 'private, max-age=30, stale-while-revalidate=60',
+      Vary: 'Cookie',
     },
   });
 });

--- a/src/app/api/conferences/route.ts
+++ b/src/app/api/conferences/route.ts
@@ -216,5 +216,24 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     }
   };
 
-  return NextResponse.json(result);
+  // Weak ETag from page fingerprint (issue #131) — clients can revalidate cheaply.
+  const etagSource = `${total}:${page}:${limit}:${domain ?? ''}:${search ?? ''}:${cfpOnly}:${formattedConferences.map((c) => c.id).join(',')}`;
+  const etag = `"c-${Buffer.from(etagSource).toString('base64url').slice(0, 27)}"`;
+  const ifNoneMatch = request.headers.get('if-none-match');
+  if (ifNoneMatch && ifNoneMatch === etag) {
+    return new NextResponse(null, {
+      status: 304,
+      headers: {
+        ETag: etag,
+        'Cache-Control': 'private, max-age=30, stale-while-revalidate=60',
+      },
+    });
+  }
+
+  return NextResponse.json(result, {
+    headers: {
+      ETag: etag,
+      'Cache-Control': 'private, max-age=30, stale-while-revalidate=60',
+    },
+  });
 });

--- a/src/app/api/conferences/route.ts
+++ b/src/app/api/conferences/route.ts
@@ -9,6 +9,7 @@ import { querySchemas } from '@/lib/apiSchemas';
 import { withErrorHandling } from '@/lib/errorHandler';
 import { ApiResponse } from '@/types/api';
 import { Prisma } from '@prisma/client';
+import { getLocalMonthYear } from '@/lib/date';
 
 /**
  * GET /api/conferences
@@ -82,7 +83,11 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   apiLogger.time('dbQuery');
   const skip = (page - 1) * limit;
+  const userId = session?.user?.id;
 
+  // Attendance: use `_count` for totals (issue #84) and a tiny preview
+  // relation (take 5) instead of loading full attendance rows just to count.
+  // isAttending is resolved with a single batched query for the page of IDs.
   const [conferences, total] = await Promise.all([
     prisma.conference.findMany({
       where,
@@ -106,68 +111,43 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         source: true,
         tags: true,
         financialAid: true,
-        ...(session?.user ? {
-          attendances: {
-            select: {
-              userId: true,
-              user: {
-                select: {
-                  image: true,
-                  name: true
-                }
-              }
-            },
-            take: 5
-          }
-        } : {})
+        _count: { select: { attendances: true } },
+        attendances: {
+          select: {
+            user: { select: { image: true, name: true } },
+          },
+          take: 5,
+          orderBy: { createdAt: 'desc' },
+        },
       },
       orderBy: { startDate: 'asc' },
       skip,
       take: limit,
     }),
-    prisma.conference.count({ where })
+    prisma.conference.count({ where }),
   ]);
-  apiLogger.timeEnd('dbQuery');
 
-  interface DbConferenceWithAttendances {
-    id: string;
-    name: string;
-    url: string;
-    startDate: Date | null;
-    endDate: Date | null;
-    city: string | null;
-    country: string | null;
-    locationRaw: string | null;
-    lat: number | null;
-    lng: number | null;
-    online: boolean;
-    cfpUrl: string | null;
-    cfpEndDate: Date | null;
-    cfpStatus: string | null;
-    domain: string;
-    description: string | null;
-    source: string;
-    tags: string[];
-    financialAid: unknown;
-    attendances?: {
-      userId: string;
-      user: {
-        image: string | null;
-        name: string | null;
-      };
-    }[];
+  const attendingSet = new Set<string>();
+  if (userId && conferences.length > 0) {
+    const myAttendance = await prisma.attendance.findMany({
+      where: {
+        userId,
+        conferenceId: { in: conferences.map((c) => c.id) },
+      },
+      select: { conferenceId: true },
+    });
+    for (const row of myAttendance) {
+      attendingSet.add(row.conferenceId);
+    }
   }
-
-  const dbConfs = conferences as unknown as DbConferenceWithAttendances[];
+  apiLogger.timeEnd('dbQuery');
 
   const months: Record<string, Conference[]> = {};
   const byDomain: Record<string, number> = {};
   let withOpenCFP = 0;
   let withLocation = 0;
 
-  const formattedConferences = dbConfs.map((c) => {
-    const attendances = c.attendances || [];
-    
+  const formattedConferences = conferences.map((c) => {
     return {
       id: c.id,
       name: c.name,
@@ -179,29 +159,26 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         country: c.country || '',
         raw: c.locationRaw || '',
         lat: c.lat || undefined,
-        lng: c.lng || undefined
+        lng: c.lng || undefined,
       },
       online: c.online,
       cfp: {
         url: c.cfpUrl || '',
         endDate: c.cfpEndDate ? c.cfpEndDate.toISOString().split('T')[0] : null,
-        status: (c.cfpStatus as 'open' | 'closed' | undefined)
+        status: (c.cfpStatus as 'open' | 'closed' | undefined),
       },
       domain: c.domain,
       description: c.description || undefined,
       source: c.source,
       tags: c.tags,
-      // Prisma Json fields are already plain JS values — the
-      // JSON.parse(JSON.stringify()) deep clone was a no-op with real cost.
+      // Prisma Json fields are already plain JS values.
       financialAid: (c.financialAid ?? undefined) as Conference['financialAid'],
-      ...(session?.user ? {
-        attendeeCount: attendances.length,
-        isAttending: attendances.some((a: { userId: string }) => a.userId === session.user.id),
-        attendees: attendances.slice(0, 5).map((a: { user: { image: string | null; name: string | null } }) => ({
-          image: a.user.image,
-          name: a.user.name
-        }))
-      } : {})
+      attendeeCount: c._count.attendances,
+      isAttending: userId ? attendingSet.has(c.id) : false,
+      attendees: c.attendances.map((a) => ({
+        image: a.user.image,
+        name: a.user.name,
+      })),
     };
   });
 
@@ -210,10 +187,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     if (conf.cfp?.status === 'open') withOpenCFP++;
     if (conf.location.lat) withLocation++;
 
-    const monthKey = conf.startDate
-      ? new Date(conf.startDate).toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
-      : 'TBD';
-    
+    const monthKey = conf.startDate ? getLocalMonthYear(conf.startDate) : 'TBD';
+
     if (!months[monthKey]) months[monthKey] = [];
     months[monthKey].push(conf);
   }

--- a/src/app/api/cron/digest/route.ts
+++ b/src/app/api/cron/digest/route.ts
@@ -52,12 +52,32 @@ function filterConferencesForUser(
   preferences: SubscriberPreferences
 ): Conference[] {
   const domain = preferences?.domain;
+  const location = (preferences?.location || preferences?.country || '').toLowerCase();
 
-  if (!domain || domain === 'all') {
-    return conferences;
-  }
+  let filtered =
+    !domain || domain === 'all'
+      ? [...conferences]
+      : conferences.filter((c) => c.domain === domain);
 
-  return conferences.filter(c => c.domain === domain);
+  // Personalization ranking (issue #64): open CFPs first, then location match,
+  // then sooner start dates. Keeps digests action-oriented without needing AI.
+  filtered.sort((a, b) => {
+    const aOpen = a.cfp?.status === 'open' ? 0 : 1;
+    const bOpen = b.cfp?.status === 'open' ? 0 : 1;
+    if (aOpen !== bOpen) return aOpen - bOpen;
+
+    if (location) {
+      const aLoc = (a.location?.raw || '').toLowerCase().includes(location) ? 0 : 1;
+      const bLoc = (b.location?.raw || '').toLowerCase().includes(location) ? 0 : 1;
+      if (aLoc !== bLoc) return aLoc - bLoc;
+    }
+
+    const aDate = a.startDate || '9999';
+    const bDate = b.startDate || '9999';
+    return aDate.localeCompare(bDate);
+  });
+
+  return filtered;
 }
 
 /**

--- a/src/app/api/cron/digest/route.ts
+++ b/src/app/api/cron/digest/route.ts
@@ -54,13 +54,14 @@ function filterConferencesForUser(
   const domain = preferences?.domain;
   const location = (preferences?.location || preferences?.country || '').toLowerCase();
 
-  let filtered =
+  const filtered =
     !domain || domain === 'all'
       ? [...conferences]
       : conferences.filter((c) => c.domain === domain);
 
   // Personalization ranking (issue #64): open CFPs first, then location match,
   // then sooner start dates. Keeps digests action-oriented without needing AI.
+  // sort mutates in place; filtered is a fresh array so callers' input is safe.
   filtered.sort((a, b) => {
     const aOpen = a.cfp?.status === 'open' ? 0 : 1;
     const bOpen = b.cfp?.status === 'open' ? 0 : 1;

--- a/src/app/api/search/suggest/route.ts
+++ b/src/app/api/search/suggest/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getCachedConferences } from '@/lib/cache';
+import { withErrorHandling, Errors } from '@/lib/errorHandler';
+import type { Conference } from '@/types/conference';
+import type { ApiResponse } from '@/types/api';
+
+/**
+ * GET /api/search/suggest?q=...
+ * Lightweight autocomplete suggestions for the search UI (issue #75).
+ */
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const q = (request.nextUrl.searchParams.get('q') || '').trim().toLowerCase();
+  if (q.length < 2) {
+    throw Errors.validation('Query must be at least 2 characters');
+  }
+  if (q.length > 80) {
+    throw Errors.validation('Query too long');
+  }
+
+  const data = await getCachedConferences();
+  const all = Object.values(data.months).flat() as Conference[];
+
+  const nameHits: string[] = [];
+  const domains = new Set<string>();
+  const tags = new Set<string>();
+
+  for (const c of all) {
+    if (nameHits.length < 8 && c.name.toLowerCase().includes(q)) {
+      nameHits.push(c.name);
+    }
+    if (c.domain?.toLowerCase().includes(q)) {
+      domains.add(c.domain);
+    }
+    for (const t of c.tags || []) {
+      if (t.toLowerCase().includes(q)) tags.add(t);
+    }
+    if (nameHits.length >= 8 && domains.size >= 5 && tags.size >= 8) break;
+  }
+
+  const response: ApiResponse = {
+    success: true,
+    data: {
+      conferences: nameHits.slice(0, 8),
+      domains: [...domains].slice(0, 5),
+      tags: [...tags].slice(0, 8),
+    },
+    meta: { timestamp: new Date().toISOString() },
+  };
+
+  return NextResponse.json(response, {
+    headers: {
+      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+    },
+  });
+});

--- a/src/app/api/search/suggest/route.ts
+++ b/src/app/api/search/suggest/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCachedConferences } from '@/lib/cache';
-import { withErrorHandling, Errors } from '@/lib/errorHandler';
+import { withErrorHandling } from '@/lib/errorHandler';
+import { querySchemas } from '@/lib/apiSchemas';
 import type { Conference } from '@/types/conference';
 import type { ApiResponse } from '@/types/api';
 
@@ -9,13 +10,9 @@ import type { ApiResponse } from '@/types/api';
  * Lightweight autocomplete suggestions for the search UI (issue #75).
  */
 export const GET = withErrorHandling(async (request: NextRequest) => {
-  const q = (request.nextUrl.searchParams.get('q') || '').trim().toLowerCase();
-  if (q.length < 2) {
-    throw Errors.validation('Query must be at least 2 characters');
-  }
-  if (q.length > 80) {
-    throw Errors.validation('Query too long');
-  }
+  const { q } = querySchemas.searchSuggest.parse({
+    q: request.nextUrl.searchParams.get('q') ?? undefined,
+  });
 
   const data = await getCachedConferences();
   const all = Object.values(data.months).flat() as Conference[];

--- a/src/app/api/user/saved-searches/route.ts
+++ b/src/app/api/user/saved-searches/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { validateCsrfToken } from '@/lib/csrf';
+import { withErrorHandling, Errors } from '@/lib/errorHandler';
+import { bodySchemas } from '@/lib/apiSchemas';
+import type { ApiResponse } from '@/types/api';
+
+/**
+ * GET /api/user/saved-searches
+ * List the authenticated user's saved search filters (issue #56).
+ */
+export const GET = withErrorHandling(async () => {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    throw Errors.unauthorized();
+  }
+
+  const searches = await prisma.savedSearch.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  const response: ApiResponse = {
+    success: true,
+    data: searches,
+    meta: { timestamp: new Date().toISOString() },
+  };
+  return NextResponse.json(response);
+});
+
+/**
+ * POST /api/user/saved-searches
+ * Persist the current filter set under a user-chosen name.
+ */
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  if (!(await validateCsrfToken(request))) {
+    throw Errors.forbidden('Invalid CSRF token');
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    throw Errors.unauthorized();
+  }
+
+  const body = await request.json();
+  const { name, filters } = bodySchemas.savedSearch.parse(body);
+
+  // Cap at 25 saved searches per user to prevent abuse.
+  const count = await prisma.savedSearch.count({
+    where: { userId: session.user.id },
+  });
+  if (count >= 25) {
+    throw Errors.validation('Maximum of 25 saved searches reached. Delete one first.');
+  }
+
+  const created = await prisma.savedSearch.create({
+    data: {
+      userId: session.user.id,
+      name,
+      filters,
+    },
+  });
+
+  const response: ApiResponse = {
+    success: true,
+    data: created,
+    meta: { timestamp: new Date().toISOString() },
+  };
+  return NextResponse.json(response, { status: 201 });
+});
+
+/**
+ * DELETE /api/user/saved-searches?id=...
+ */
+export const DELETE = withErrorHandling(async (request: NextRequest) => {
+  if (!(await validateCsrfToken(request))) {
+    throw Errors.forbidden('Invalid CSRF token');
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    throw Errors.unauthorized();
+  }
+
+  const id = request.nextUrl.searchParams.get('id');
+  if (!id || id.length > 100) {
+    throw Errors.validation('Saved search id is required');
+  }
+
+  const result = await prisma.savedSearch.deleteMany({
+    where: { id, userId: session.user.id },
+  });
+  if (result.count === 0) {
+    throw Errors.notFound('Saved search not found');
+  }
+
+  const response: ApiResponse = {
+    success: true,
+    data: { deleted: true },
+    meta: { timestamp: new Date().toISOString() },
+  };
+  return NextResponse.json(response);
+});

--- a/src/app/api/user/saved-searches/route.ts
+++ b/src/app/api/user/saved-searches/route.ts
@@ -4,7 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { validateCsrfToken } from '@/lib/csrf';
 import { withErrorHandling, Errors } from '@/lib/errorHandler';
-import { bodySchemas } from '@/lib/apiSchemas';
+import { bodySchemas, querySchemas } from '@/lib/apiSchemas';
 import type { ApiResponse } from '@/types/api';
 
 /**
@@ -84,10 +84,9 @@ export const DELETE = withErrorHandling(async (request: NextRequest) => {
     throw Errors.unauthorized();
   }
 
-  const id = request.nextUrl.searchParams.get('id');
-  if (!id || id.length > 100) {
-    throw Errors.validation('Saved search id is required');
-  }
+  const { id } = querySchemas.savedSearchId.parse({
+    id: request.nextUrl.searchParams.get('id') ?? undefined,
+  });
 
   const result = await prisma.savedSearch.deleteMany({
     where: { id, userId: session.user.id },

--- a/src/app/api/v1/conferences/route.ts
+++ b/src/app/api/v1/conferences/route.ts
@@ -33,6 +33,7 @@ export async function GET(request: Request) {
     const domain = validated.domain;
     const cfpOnly = validated.cfp_open === 'true';
     const format = validated.format;
+    const q = validated.q?.trim().toLowerCase();
 
     const data = await getCachedConferences();
 
@@ -47,6 +48,23 @@ export async function GET(request: Request) {
 
     if (cfpOnly) {
       conferences = conferences.filter(c => c.cfp?.status === 'open');
+    }
+
+    // Server-side text search for public API consumers (issue #176 / #75 path)
+    if (q) {
+      conferences = conferences.filter((c) => {
+        const hay = [
+          c.name,
+          c.description,
+          c.location?.raw,
+          c.domain,
+          ...(c.tags || []),
+        ]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase();
+        return hay.includes(q);
+      });
     }
 
     if (format === 'csv') {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,17 +86,18 @@ body {
   background-clip: text;
 }
 
-/* Touch targets — WCAG 2.5.5 / issue #79 (min ~44px interactive area) */
+/* Touch targets — WCAG 2.5.5 / issue #79 (min 44px interactive area) */
 button,
 .btn-primary,
 a.btn-primary,
 [role="button"] {
-  min-height: 2.5rem;
+  min-height: 44px;
+  min-width: 44px;
 }
 button.p-1\.5,
 button[class*="p-1.5"] {
-  min-height: 2.5rem;
-  min-width: 2.5rem;
+  min-height: 44px;
+  min-width: 44px;
 }
 
 /* Card styling */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,6 +86,19 @@ body {
   background-clip: text;
 }
 
+/* Touch targets — WCAG 2.5.5 / issue #79 (min ~44px interactive area) */
+button,
+.btn-primary,
+a.btn-primary,
+[role="button"] {
+  min-height: 2.5rem;
+}
+button.p-1\.5,
+button[class*="p-1.5"] {
+  min-height: 2.5rem;
+  min-width: 2.5rem;
+}
+
 /* Card styling */
 .card {
   background: var(--surface-card);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -375,3 +375,25 @@ input[type="checkbox"]:focus {
     transform: none;
   }
 }
+
+/* Print styles (issue #229) */
+@media print {
+  body {
+    background: white !important;
+    color: black !important;
+  }
+  header, footer, nav, .btn-primary, button, #compare-bar, [data-nosnippet] {
+    display: none !important;
+  }
+  .card {
+    break-inside: avoid;
+    box-shadow: none !important;
+    border: 1px solid #ccc !important;
+    content-visibility: visible;
+  }
+  a[href]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #444;
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,6 +91,9 @@ body {
   background: var(--surface-card);
   border: 1px solid var(--border-subtle);
   border-radius: 1rem;
+  /* Offscreen cards skip layout/paint work (issue #106) */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 228px;
   /* Specific properties only — never `transition: all` */
   transition: transform 200ms var(--ease-out-strong),
     box-shadow 200ms var(--ease-out-strong),

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -8,7 +8,10 @@ export default function CompareBar() {
   if (selectedConferences.length === 0) return null;
 
   return (
-    <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-50 bg-zinc-900 border border-zinc-700 rounded-full shadow-2xl p-2 px-6 flex items-center gap-4 animate-in slide-in-from-bottom-10 fade-in">
+    <div
+      id="compare-bar"
+      className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-50 bg-zinc-900 border border-zinc-700 rounded-full shadow-2xl p-2 px-6 flex items-center gap-4 animate-in slide-in-from-bottom-10 fade-in"
+    >
       <div className="flex -space-x-2">
         {selectedConferences.map(c => (
           <div key={c.id} className="relative group">

--- a/src/components/ConferenceCard.tsx
+++ b/src/components/ConferenceCard.tsx
@@ -13,10 +13,14 @@ import { type Conference, DOMAIN_INFO } from '@/types/conference';
 import { useCompare } from '@/context/CompareContext';
 import { SafeHighlightedText } from '@/components/SafeHighlightedText';
 import { SafeImage } from '@/components/SafeImage';
-import VisaModal from './VisaModal';
-import TravelModal from './TravelModal';
+import dynamic from 'next/dynamic';
+import ShareButtons from '@/components/ShareButtons';
 import { secureFetch } from '@/lib/api';
 import { parseLocalDate } from '@/lib/date';
+
+// Lazy-load modals so the default card grid does not pay for modal JS (issue #100).
+const VisaModal = dynamic(() => import('./VisaModal'), { ssr: false });
+const TravelModal = dynamic(() => import('./TravelModal'), { ssr: false });
 
 interface ConferenceCardProps {
   conference: Omit<Conference, 'description'>;
@@ -315,6 +319,12 @@ const ConferenceCard = memo(function ConferenceCard({ conference, searchTerm }: 
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
               </svg>
             </button>
+
+            <ShareButtons
+              url={conference.url}
+              title={conference.name}
+              text={`Check out ${conference.name} on ConfScouting`}
+            />
 
             {/* Visa Support Button */}
             {!conference.online && (

--- a/src/components/SafeHighlightedText.tsx
+++ b/src/components/SafeHighlightedText.tsx
@@ -1,11 +1,14 @@
 /**
  * SafeHighlightedText Component
- * 
+ *
  * A secure alternative to dangerouslySetInnerHTML for highlighting search terms.
  * Uses React's safe rendering to prevent XSS attacks.
+ *
+ * Issue #94: avoid building a RegExp on every render for the common case.
+ * Case-insensitive indexOf scanning is faster and ReDoS-safe for plain terms.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 interface SafeHighlightedTextProps {
   text: string;
@@ -13,52 +16,93 @@ interface SafeHighlightedTextProps {
   className?: string;
 }
 
-/**
- * Escape special regex characters to prevent ReDoS attacks
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+interface HighlightPart {
+  key: string;
+  value: string;
+  match: boolean;
 }
 
 /**
- * Safely highlight search terms in text without using dangerouslySetInnerHTML
- * This prevents XSS attacks by using React's built-in escaping
+ * Split `text` into alternating non-match / match segments without RegExp.
  */
-export function SafeHighlightedText({ text, searchTerm, className = '' }: SafeHighlightedTextProps) {
+function splitHighlight(text: string, term: string): HighlightPart[] {
+  if (!term || !text) {
+    return [{ key: 'full', value: text, match: false }];
+  }
+
+  const safeTerm = term.slice(0, 100);
+  const lowerText = text.toLowerCase();
+  const lowerTerm = safeTerm.toLowerCase();
+  if (!lowerTerm) {
+    return [{ key: 'full', value: text, match: false }];
+  }
+
+  const parts: HighlightPart[] = [];
+  let start = 0;
+  let idx = lowerText.indexOf(lowerTerm, start);
+  let n = 0;
+
+  while (idx !== -1) {
+    if (idx > start) {
+      parts.push({
+        key: `t-${n++}`,
+        value: text.slice(start, idx),
+        match: false,
+      });
+    }
+    parts.push({
+      key: `m-${n++}`,
+      value: text.slice(idx, idx + safeTerm.length),
+      match: true,
+    });
+    start = idx + safeTerm.length;
+    idx = lowerText.indexOf(lowerTerm, start);
+  }
+
+  if (start < text.length) {
+    parts.push({
+      key: `t-${n++}`,
+      value: text.slice(start),
+      match: false,
+    });
+  }
+
+  return parts.length > 0 ? parts : [{ key: 'full', value: text, match: false }];
+}
+
+/**
+ * Safely highlight search terms in text without using dangerouslySetInnerHTML.
+ */
+export function SafeHighlightedText({
+  text,
+  searchTerm,
+  className = '',
+}: SafeHighlightedTextProps) {
+  const parts = useMemo(
+    () => splitHighlight(text, searchTerm),
+    [text, searchTerm]
+  );
+
   if (!searchTerm || !text) {
     return <span className={className}>{text}</span>;
   }
 
-  try {
-    // Limit search term length to prevent ReDoS
-    const safeSearchTerm = searchTerm.slice(0, 100);
-    const escapedTerm = escapeRegExp(safeSearchTerm);
-    
-    // Use a safe regex with a reasonable complexity
-    const parts = text.split(new RegExp(`(${escapedTerm})`, 'gi'));
-    
-    return (
-      <span className={className}>
-        {parts.map((part, index) => {
-          // Case-insensitive comparison for highlighting
-          if (part.toLowerCase() === safeSearchTerm.toLowerCase()) {
-            return (
-              <mark 
-                key={`hl-${index}`} 
-                className="bg-blue-500/30 text-blue-300 rounded px-0.5"
-              >
-                {part}
-              </mark>
-            );
-          }
-          return <span key={`tx-${index}`}>{part}</span>;
-        })}
-      </span>
-    );
-  } catch {
-    // Fallback to plain text if regex fails
-    return <span className={className}>{text}</span>;
-  }
+  return (
+    <span className={className}>
+      {parts.map((part) =>
+        part.match ? (
+          <mark
+            key={part.key}
+            className="bg-blue-500/30 text-blue-300 rounded px-0.5"
+          >
+            {part.value}
+          </mark>
+        ) : (
+          <span key={part.key}>{part.value}</span>
+        )
+      )}
+    </span>
+  );
 }
 
 export default SafeHighlightedText;

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Registers the production service worker (issue #74).
+ * Skipped in development to avoid stale Turbopack assets.
+ */
+export default function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+
+    const register = async () => {
+      try {
+        await navigator.serviceWorker.register('/sw.js', { scope: '/' });
+      } catch (err) {
+        console.warn('[sw] registration failed', err);
+      }
+    };
+
+    // Defer until idle so it does not contend with hydration.
+    const ric = (
+      window as Window & {
+        requestIdleCallback?: (cb: () => void) => number;
+      }
+    ).requestIdleCallback;
+    if (typeof ric === 'function') {
+      ric(() => void register());
+    } else {
+      globalThis.setTimeout(() => void register(), 2000);
+    }
+  }, []);
+
+  return null;
+}

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useEffect } from 'react';
+import Logger from '@/lib/logger';
+
+const swLogger = new Logger('SW');
 
 /**
  * Registers the production service worker (issue #74).
@@ -15,7 +18,9 @@ export default function ServiceWorkerRegister() {
       try {
         await navigator.serviceWorker.register('/sw.js', { scope: '/' });
       } catch (err) {
-        console.warn('[sw] registration failed', err);
+        swLogger.warn('registration failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     };
 

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -34,25 +34,13 @@ export default function ShareButtons({
 
   const shareText = text || title;
 
-  const handleNativeShare = useCallback(async () => {
-    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
-      try {
-        await navigator.share({ title, text: shareText, url: absoluteUrl });
-        return;
-      } catch {
-        // User cancelled or share failed — fall through to copy.
-      }
-    }
-    await handleCopy();
-  }, [absoluteUrl, shareText, title]);
-
   const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(absoluteUrl);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Fallback for older browsers
+      // Fallback for older browsers / denied clipboard permission
       const input = document.createElement('input');
       input.value = absoluteUrl;
       document.body.appendChild(input);
@@ -64,6 +52,18 @@ export default function ShareButtons({
     }
   }, [absoluteUrl]);
 
+  const handleNativeShare = useCallback(async () => {
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ title, text: shareText, url: absoluteUrl });
+        return;
+      } catch {
+        // User cancelled or share failed — fall through to copy.
+      }
+    }
+    await handleCopy();
+  }, [absoluteUrl, shareText, title, handleCopy]);
+
   const encodedUrl = encodeURIComponent(absoluteUrl);
   const encodedText = encodeURIComponent(shareText);
 
@@ -71,7 +71,7 @@ export default function ShareButtons({
     <div className={`flex items-center gap-1.5 ${className}`}>
       <button
         type="button"
-        onClick={handleNativeShare}
+        onClick={() => void handleNativeShare()}
         aria-label="Share conference"
         className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 border border-transparent hover:border-zinc-700 transition-colors"
         title="Share"
@@ -83,7 +83,7 @@ export default function ShareButtons({
 
       <button
         type="button"
-        onClick={handleCopy}
+        onClick={() => void handleCopy()}
         aria-label={copied ? 'Link copied' : 'Copy link'}
         className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 border border-transparent hover:border-zinc-700 transition-colors"
         title={copied ? 'Copied!' : 'Copy link'}

--- a/src/components/ShareButtons.tsx
+++ b/src/components/ShareButtons.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+interface ShareButtonsProps {
+  /** Absolute or site-relative URL of the resource to share */
+  url: string;
+  title: string;
+  /** Optional short text for Twitter/LinkedIn */
+  text?: string;
+  className?: string;
+}
+
+/**
+ * Compact share controls (issue #67).
+ * Uses the Web Share API when available, with copy-link + social fallbacks.
+ */
+export default function ShareButtons({
+  url,
+  title,
+  text,
+  className = '',
+}: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false);
+
+  const absoluteUrl = (() => {
+    if (typeof window === 'undefined') return url;
+    try {
+      return new URL(url, window.location.origin).toString();
+    } catch {
+      return url;
+    }
+  })();
+
+  const shareText = text || title;
+
+  const handleNativeShare = useCallback(async () => {
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ title, text: shareText, url: absoluteUrl });
+        return;
+      } catch {
+        // User cancelled or share failed — fall through to copy.
+      }
+    }
+    await handleCopy();
+  }, [absoluteUrl, shareText, title]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(absoluteUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers
+      const input = document.createElement('input');
+      input.value = absoluteUrl;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand('copy');
+      document.body.removeChild(input);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    }
+  }, [absoluteUrl]);
+
+  const encodedUrl = encodeURIComponent(absoluteUrl);
+  const encodedText = encodeURIComponent(shareText);
+
+  return (
+    <div className={`flex items-center gap-1.5 ${className}`}>
+      <button
+        type="button"
+        onClick={handleNativeShare}
+        aria-label="Share conference"
+        className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 border border-transparent hover:border-zinc-700 transition-colors"
+        title="Share"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+        </svg>
+      </button>
+
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? 'Link copied' : 'Copy link'}
+        className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 border border-transparent hover:border-zinc-700 transition-colors"
+        title={copied ? 'Copied!' : 'Copy link'}
+      >
+        {copied ? (
+          <svg className="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        ) : (
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+          </svg>
+        )}
+      </button>
+
+      <a
+        href={`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedText}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on X (Twitter)"
+        className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 border border-transparent hover:border-zinc-700 transition-colors"
+        title="Share on X"
+      >
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.727-8.835L1.254 2.25H8.08l4.253 5.622L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z" />
+        </svg>
+      </a>
+
+      <a
+        href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on LinkedIn"
+        className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 border border-transparent hover:border-zinc-700 transition-colors"
+        title="Share on LinkedIn"
+      >
+        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+      </a>
+    </div>
+  );
+}

--- a/src/context/CompareContext.tsx
+++ b/src/context/CompareContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, ReactNode, useEffect, useMemo, useCallback, useRef } from 'react';
 import type { Conference } from '@/types/conference';
 import { isValidConference } from '@/lib/validation';
+import { safeGetItem, safeSetItem, safeParseJson } from '@/lib/safeStorage';
 
 interface CompareContextType {
   selectedConferences: Conference[];
@@ -19,27 +20,16 @@ export function CompareProvider({ children }: { children: ReactNode }) {
 
   // Load from session storage on mount (more secure than localStorage for ephemeral data)
   useEffect(() => {
-    try {
-      const saved = sessionStorage.getItem('compare_conferences');
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        if (Array.isArray(parsed)) {
-          const validated = parsed.filter(isValidConference);
-          setSelectedConferences(validated);
-        }
-      }
-    } catch {
-      console.warn('Failed to load compare data from storage');
+    const saved = safeGetItem('session', 'compare_conferences');
+    const parsed = safeParseJson<unknown>(saved, null);
+    if (Array.isArray(parsed)) {
+      setSelectedConferences(parsed.filter(isValidConference));
     }
   }, []);
 
-  // Save to session storage on change
+  // Save to session storage on change (quota-safe — issue #223)
   useEffect(() => {
-    try {
-      sessionStorage.setItem('compare_conferences', JSON.stringify(selectedConferences));
-    } catch {
-      console.warn('Failed to save compare data to storage');
-    }
+    safeSetItem('session', 'compare_conferences', JSON.stringify(selectedConferences));
   }, [selectedConferences]);
 
   // Latest-value ref so addToCompare stays stable without stale closures.

--- a/src/context/CompareContext.tsx
+++ b/src/context/CompareContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState, ReactNode, useEffect, useMemo, useCallback, useRef } from 'react';
+import { createContext, useContext, useState, ReactNode, useEffect, useMemo, useCallback } from 'react';
 import type { Conference } from '@/types/conference';
 import { isValidConference } from '@/lib/validation';
 import { safeGetItem, safeSetItem, safeParseJson } from '@/lib/safeStorage';
@@ -32,20 +32,22 @@ export function CompareProvider({ children }: { children: ReactNode }) {
     safeSetItem('session', 'compare_conferences', JSON.stringify(selectedConferences));
   }, [selectedConferences]);
 
-  // Latest-value ref so addToCompare stays stable without stale closures.
-  const selectedRef = useRef(selectedConferences);
-  useEffect(() => {
-    selectedRef.current = selectedConferences;
-  }, [selectedConferences]);
-
+  // Functional updater so rapid sequential adds (e.g. deep-link ?ids= hydration)
+  // never drop conferences due to a stale selectedRef snapshot.
   const addToCompare = useCallback((conf: Conference) => {
-    const current = selectedRef.current;
-    if (current.length >= 4) {
-      alert("You can only compare up to 4 conferences.");
-      return;
-    }
-    if (current.find(c => c.id === conf.id)) return;
-    setSelectedConferences([...current, conf]);
+    setSelectedConferences((current) => {
+      if (current.some((c) => c.id === conf.id)) {
+        return current;
+      }
+      if (current.length >= 4) {
+        // Defer alert so we stay pure inside the updater
+        queueMicrotask(() => {
+          alert('You can only compare up to 4 conferences.');
+        });
+        return current;
+      }
+      return [...current, conf];
+    });
   }, []);
 
   const removeFromCompare = useCallback((confId: string) => {

--- a/src/lib/apiSchemas.ts
+++ b/src/lib/apiSchemas.ts
@@ -233,6 +233,22 @@ export const bodySchemas = {
     data => data.interests || data.bio,
     { message: 'Either interests or bio must be provided', path: ['interests'] }
   ),
+
+  /**
+   * Saved search create body (issue #56)
+   */
+  savedSearch: z.object({
+    name: z.string()
+      .min(1, 'Name is required')
+      .max(80, 'Name too long')
+      .regex(patterns.safeString, 'Invalid characters in name'),
+    filters: z.object({
+      q: z.string().max(200).optional(),
+      domain: z.string().max(50).optional(),
+      cfp: z.boolean().optional(),
+      sortBy: z.string().max(40).optional(),
+    }).strict(),
+  }),
 };
 
 /**

--- a/src/lib/apiSchemas.ts
+++ b/src/lib/apiSchemas.ts
@@ -80,6 +80,10 @@ export const querySchemas = {
       z.literal('all'),
     ]).optional(),
     cfp_open: z.enum(['true', 'false']).optional(),
+    q: z.string()
+      .max(200, 'Search query too long')
+      .regex(patterns.safeString, 'Invalid characters in search')
+      .optional(),
     format: z.enum(['json', 'csv']).default('json'),
   }),
 

--- a/src/lib/apiSchemas.ts
+++ b/src/lib/apiSchemas.ts
@@ -95,6 +95,41 @@ export const querySchemas = {
       .regex(patterns.conferenceId, 'Invalid conference ID')
       .max(100, 'Conference ID too long'),
   }),
+
+  /**
+   * Search autocomplete query (issue #75)
+   */
+  searchSuggest: z.object({
+    q: z.string()
+      .trim()
+      .min(2, 'Query must be at least 2 characters')
+      .max(80, 'Query too long')
+      .regex(patterns.safeString, 'Invalid characters in search')
+      .transform((s) => s.toLowerCase()),
+  }),
+
+  /**
+   * Related conferences query (issue #70)
+   */
+  relatedConferences: z.object({
+    id: z.string()
+      .min(1, 'Conference id is required')
+      .max(120, 'Conference id too long')
+      .regex(patterns.conferenceId, 'Invalid conference ID'),
+    limit: z.preprocess(
+      (val) => (val === null || val === undefined || val === '' ? undefined : val),
+      z.coerce.number().int().min(1).max(12).default(6)
+    ),
+  }),
+
+  /**
+   * Saved-search delete query
+   */
+  savedSearchId: z.object({
+    id: z.string()
+      .min(1, 'Saved search id is required')
+      .max(100, 'Saved search id too long'),
+  }),
 };
 
 /**
@@ -247,7 +282,10 @@ export const bodySchemas = {
       .max(80, 'Name too long')
       .regex(patterns.safeString, 'Invalid characters in name'),
     filters: z.object({
-      q: z.string().max(200).optional(),
+      q: z.string()
+        .max(200, 'Search query too long')
+        .regex(patterns.safeString, 'Invalid characters in search')
+        .optional(),
       domain: z.string().max(50).optional(),
       cfp: z.boolean().optional(),
       sortBy: z.string().max(40).optional(),

--- a/src/lib/safeStorage.ts
+++ b/src/lib/safeStorage.ts
@@ -1,0 +1,63 @@
+/**
+ * Quota-safe storage helpers (issues #162, #163, #223).
+ * sessionStorage/localStorage can throw QuotaExceededError in private mode
+ * or when the origin is full — never let that crash the UI.
+ */
+
+export type StorageKind = 'local' | 'session';
+
+function getStore(kind: StorageKind): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return kind === 'local' ? window.localStorage : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function safeGetItem(kind: StorageKind, key: string): string | null {
+  const store = getStore(kind);
+  if (!store) return null;
+  try {
+    return store.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSetItem(kind: StorageKind, key: string, value: string): boolean {
+  const store = getStore(kind);
+  if (!store) return false;
+  try {
+    store.setItem(key, value);
+    return true;
+  } catch {
+    // Quota exceeded — try to free compare/ephemeral keys then retry once.
+    try {
+      store.removeItem(key);
+      store.setItem(key, value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export function safeRemoveItem(kind: StorageKind, key: string): void {
+  const store = getStore(kind);
+  if (!store) return;
+  try {
+    store.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+export function safeParseJson<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary

Implements and closes the bulk of open GitHub issues that did **not** require product/ops decisions. Work is on `fix/open-issues-remediation` (8 commits). Issues needing admin input (admin CRUD, reviews, mobile app, API keys, multi-language policy, etc.) remain open with comments.

### High-impact features
- **#56** Saved searches API + search UI (signed-in, max 25)
- **#67** Share buttons (Web Share, copy, X, LinkedIn)
- **#74** Production service worker (`public/sw.js`) for shell caching
- **#78** Compare deep-links (`?ids=`), richer columns, share controls
- **#70** Related conferences API (`/api/conferences/related`)
- **#75** Search autocomplete (`/api/search/suggest` + datalist)
- **#64** Digest ranking: open CFPs + location match first

### Performance & reliability
- **#84 / #177** Attendance via Prisma `_count` + batched `isAttending`
- **#205 / #206** Atomic geocode cache write + `.bak` restore
- **#86 / #87 / #178** Parallel confs.tech + Sessionize fetches
- **#94 / #100** Faster highlights; lazy-loaded modals
- **#106 / #131** `content-visibility` on cards; ETag/304 on conference API
- **#104** Prefer `lxml` when installed
- **#176** Server-side `?q=` on public v1 API

### A11y / polish / docs
- Skip-to-content, print styles, touch targets
- Quota-safe storage helpers
- `docs/KEY_ROTATION.md` (#292)

### Verification
- `npx tsc --noEmit` clean
- `npm test` — **477/477** pass

### Left open (needs Mohit)
#16, #57, #58, #59, #62, #63, #65, #66, #68, #69, #77, #80, #130

## Test plan
- [ ] CI green (lint, tests, security, build)
- [ ] Search: save/apply/delete search while signed in
- [ ] Share + compare `?ids=` deep link
- [ ] `/api/conferences/related?id=…` and `/api/search/suggest?q=…`
- [ ] Production-only SW registers without caching `/api`
- [ ] Preview: home/search still fast; attendance counts look correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save, apply, and delete personalized searches when signed in.
  * Get autocomplete suggestions for conference names, domains, and tags.
  * Share conference cards and comparison links through native and social sharing.
  * Compare conferences using shareable links, with improved controls and loading behavior.
  * Discover related conferences and search across additional conference details.
  * Enjoy faster repeat visits through improved offline-ready browsing support.

* **Bug Fixes**
  * Improved reliability when saving comparison and cached data.
  * Added accessible skip navigation, larger touch targets, and print-friendly layouts.
  * Improved conference recommendations in digest notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->